### PR TITLE
Ignore the .vs folder instead of .sln.ide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ build/nuget/
 # Per-user files created by IDEs
 *.suo
 *.user
-*.sln.ide/
+*.vs/


### PR DESCRIPTION
Starting with Visual Studio 2015 CTP 5, the Roslyn IntelliSense cache folder is
named .vs instead of .sln.ide.